### PR TITLE
Cpu only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 __pycache__
 .DS_Store
 .DS_store
-
+*.pdf
+*.png
+*.pth

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__
+.DS_Store
+.DS_store
+


### PR DESCRIPTION
Was throwing the following error on non-cuda enabled pytorch:

```
Traceback (most recent call last):
  File "main.py", line 343, in <module>
    main()
  File "main.py", line 203, in main
    output = netD(input)
  File "/Users/areustle/anaconda/envs/py3/lib/python3.6/site-packages/torch/nn/modules/module.py", line 477, in __call__
    result = self.forward(*input, **kwargs)
  File "main.py", line 99, in forward
    if isinstance(input.data, torch.cuda.FloatTensor) and self.ngpu > 1:
RuntimeError: Cannot initialize CUDA without ATen_cuda library. PyTorch splits its backend into two shared libraries: a CPU library and a CUDA library; this error has occurred because you are trying to use some CUDA functionality, but the CUDA library has not been loaded by the dynamic linker for some reason.  The CUDA library MUST be loaded, EVEN IF you don't directly use any symbols from the CUDA library! One common culprit is a lack of -Wl,--no-as-needed in your link arguments; many dynamic linkers will delete dynamic library dependencies if you don't depend on any of their symbols.  You can check if this has occurred by using ldd on your binary to see if there is a dependency on *_cuda.so library.
```

Reordered conditional check in the network's `forward` function so `self.ngpu` is evaluated first. Added block setting `ngpu = 0` if cuda is not available.

Also added a .gitignore